### PR TITLE
cmake: minor cosmetics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,13 +2,12 @@
 cmake_minimum_required(VERSION 3.12)
 
 project(Camtimers)
-ENABLE_LANGUAGE(C Fortran)
-set(Fortran_FORMAT FREE)
+enable_language(C Fortran)
 
 find_package(MPI REQUIRED)
 find_package(OpenMP)
 
-# CLone the perfstubs repo if it doesn't exist
+# Clone the perfstubs repo if it doesn't exist
 
 if(NOT EXISTS "${PROJECT_SOURCE_DIR}/perfstubs/CMakeLists.txt")
 include(cmake/GitUtils.cmake)
@@ -61,4 +60,3 @@ install (FILES ${CMAKE_BINARY_DIR}/perf_utils.mod DESTINATION include)
 # provide under CAMTIMERS::CAMTIMERS name
 add_library(CAMTIMERS::CAMTIMERS INTERFACE IMPORTED GLOBAL)
 target_link_libraries(CAMTIMERS::CAMTIMERS INTERFACE timers)
-


### PR DESCRIPTION
and remove `set(Fortran_FORMAT FREE)`, because it doesn't work like that
(should be `CMAKE_Fortran_FORMAT`), but is also not needed, since the
source files are suffixed .F90.