### PR TITLE
Updates for camtimers+perfstubs on spock

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,14 @@ enable_language(C Fortran)
 
 if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
   include(CheckFortranCompilerFlag)
-  check_fortran_compiler_flag("-fallow-argument-mismatch" _flag)
+  check_fortran_compiler_flag("-Wno-argument-mismatch" _flag)
   if (_flag)
     set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${_flag}")
+  else()
+    check_fortran_compiler_flag("-fallow-argument-mismatch" _flag)
+    if (_flag)
+        set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${_flag}")
+    endif()
   endif()
 endif()
 
@@ -17,7 +22,16 @@ if (CMAKE_Fortran_COMPILER_ID STREQUAL "Cray")
     set (CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ef")
 endif()
 
-find_package(MPI REQUIRED)
+#set (CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -Wall")
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+
+# Allow the user to disable MPI support
+if (NOT DEFINED CAMTIMERS_USE_MPI)
+    set (CAMTIMERS_USE_MPI ON)
+endif ()
+if (CAMTIMERS_USE_MPI)
+    find_package(MPI)
+endif ()
 find_package(OpenMP)
 
 # Clone the perfstubs repo if it doesn't exist
@@ -57,12 +71,21 @@ add_library(timers
   perf_mod.F90
   perf_utils.F90)
 
-target_compile_definitions(timers PRIVATE FORTRANUNDERSCORE HAVE_MPI LINUX PERFSTUBS_USE_TIMERS)
-target_link_libraries(timers PUBLIC MPI::MPI_C global_settings)
+if (MPI_FOUND)
+    target_compile_definitions(timers PRIVATE HAVE_MPI )
+endif (MPI_FOUND)
+
+target_compile_definitions(timers PRIVATE FORTRANUNDERSCORE LINUX PERFSTUBS_USE_TIMERS)
+
+if (MPI_FOUND)
+    target_link_libraries(timers PUBLIC MPI::MPI_C global_settings)
+endif (MPI_FOUND)
+
 if(OpenMP_FOUND)
     target_link_libraries(timers PRIVATE OpenMP::OpenMP_C)
     target_link_libraries(timers PRIVATE OpenMP::OpenMP_Fortran)
 endif(OpenMP_FOUND)
+
 target_include_directories(timers PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/perfstubs)
 
 install(TARGETS timers)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,11 +73,6 @@ add_library(timers
 
 if (MPI_FOUND)
     target_compile_definitions(timers PRIVATE HAVE_MPI )
-endif (MPI_FOUND)
-
-target_compile_definitions(timers PRIVATE FORTRANUNDERSCORE LINUX PERFSTUBS_USE_TIMERS)
-
-if (MPI_FOUND)
     target_link_libraries(timers PUBLIC MPI::MPI_C global_settings)
 endif (MPI_FOUND)
 
@@ -86,6 +81,7 @@ if(OpenMP_FOUND)
     target_link_libraries(timers PRIVATE OpenMP::OpenMP_Fortran)
 endif(OpenMP_FOUND)
 
+target_compile_definitions(timers PRIVATE FORTRANUNDERSCORE LINUX PERFSTUBS_USE_TIMERS)
 target_include_directories(timers PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/perfstubs)
 
 install(TARGETS timers)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,11 @@ if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
   endif()
 endif()
 
+# If using the cray fortran wrapper, force lowercase module names
+if (CMAKE_Fortran_COMPILER_ID STREQUAL "Cray")
+    set (CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ef")
+endif()
+
 find_package(MPI REQUIRED)
 find_package(OpenMP)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,11 +26,9 @@ endif()
 set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 
 # Allow the user to disable MPI support
-if (NOT DEFINED CAMTIMERS_USE_MPI)
-    set (CAMTIMERS_USE_MPI ON)
-endif ()
+option(CAMTIMERS_USE_MPI "Build camtimers with MPI" ON)
 if (CAMTIMERS_USE_MPI)
-    find_package(MPI)
+    find_package(MPI REQUIRED)
 endif ()
 find_package(OpenMP)
 

--- a/GPTLutil.c
+++ b/GPTLutil.c
@@ -72,7 +72,7 @@ void GPTLset_abort_on_error (bool val)
 
 void *GPTLallocate (const int nbytes)
 {
-  void *ptr;
+  void *ptr = NULL;
 
   if ( nbytes <= 0 || ! (ptr = malloc (nbytes)))
     (void) GPTLerror ("GPTLallocate: malloc failed for %d bytes\n", nbytes);

--- a/gptl.c
+++ b/gptl.c
@@ -3865,7 +3865,7 @@ int GPTLpr_summary_file (int comm,
   FILE *fp = 0;                    /* output file */
 
   int count;                       /* number of timers */
-  Summarystats *storage;           /* storage for data from all timers */
+  Summarystats *storage = NULL;    /* storage for data from all timers */
 
   int x;                           /* pointer increment */
   int k;                           /* counter */
@@ -4507,6 +4507,7 @@ static int ncmp( const void *pa, const void *pb )
     return -1;
   /* if( *x == *y ) */
   GPTLerror("%s: shared memory address between timers\n", thisfunc);
+  return 0;
 }
 
 /*

--- a/perf_mod.F90
+++ b/perf_mod.F90
@@ -157,7 +157,7 @@ module perf_mod
 
    logical, parameter :: def_perf_add_detail = .false.         ! default
    logical, private   :: perf_add_detail = def_perf_add_detail
-                         ! flag indicating whether to add the current 
+                         ! flag indicating whether to add the current
                          ! detail level as a suffix to the timer name.
                          ! This requires that even t_startf/t_stopf
                          ! and t_accel_startf/t_accel_stopf calls
@@ -866,7 +866,7 @@ contains
 !---------------------------Local workspace-----------------------------
 !
    integer  ierr                          ! GPTL error return
-   integer  str_length, i                 ! support for adding 
+   integer  str_length, i                 ! support for adding
                                           !  detail suffix
    character(len=2) cdetail               ! char variable for detail
    integer  callcnt                       ! call count increment
@@ -947,7 +947,7 @@ contains
    subroutine t_accel_startf(event, accelid, handle)
 !-----------------------------------------------------------------------
 ! Purpose: Start an event timer for launching a task on an accelerator.
-!          Also create event timer to hold time spent on accelerator, 
+!          Also create event timer to hold time spent on accelerator,
 !          using accelid as a virtual thread id.
 ! Author: P. Worley and S. Abbott.
 !-----------------------------------------------------------------------
@@ -1639,7 +1639,7 @@ contains
    logical, optional,  intent(IN) :: MasterTask      ! If MPI master task
    integer, optional,  intent(IN) :: MaxThreads      ! maximum number of threads
                                                      !  used by components
-   integer, optional,  intent(IN) :: MaxAccelerators ! maximum number of 
+   integer, optional,  intent(IN) :: MaxAccelerators ! maximum number of
                                                      !  accelerators used by a
                                                      !  process
 !


### PR DESCRIPTION
Adding support for building camtimers+perfstubs on spock.  Adds the ability to configure without MPI support (for testing XGC kernels, for example).